### PR TITLE
Feature/do not create configuration hard to override

### DIFF
--- a/helm/persistence/values.yaml
+++ b/helm/persistence/values.yaml
@@ -74,7 +74,7 @@ users: []
 #      - user
 
 # Create queues
-queues: {}
+queues: []
 #  - name: QUEUE_1
 #    dlq_address: QUEUE_1_DLQ
 #    expiry_address:

--- a/helm/persistence/values.yaml
+++ b/helm/persistence/values.yaml
@@ -62,38 +62,40 @@ admin:
   roles:
     - admin
 
-users:
-  - name: demouser
-    password: "demo"
-    roles:
-      - user
-  - name: anotheruser
-    password: "demo1"
-    roles:
-      - user
+# Create additional users
+users: []
+#  - name: demouser
+#    password: "demo"
+#    roles:
+#      - user
+#  - name: anotheruser
+#    password: "demo1"
+#    roles:
+#      - user
 
-queues:
-  - name: QUEUE_1
-    dlq_address: QUEUE_1_DLQ
-    expiry_address:
-    max_delivery_attempts:
-    redelivery_delay:
-    max_size_bytes:
-    message_counter_history_day_limit:
-    address_full_policy:
-    permissions:
-      - grant: consume
-        roles:
-          - admin
-          - user
-      - grant: browse
-        roles:
-          - admin
-          - user
-      - grant: send
-        roles:
-          - admin
-          - user
-      - grant: manage
-        roles:
-          - admin
+# Create queues
+queues: {}
+#  - name: QUEUE_1
+#    dlq_address: QUEUE_1_DLQ
+#    expiry_address:
+#    max_delivery_attempts:
+#    redelivery_delay:
+#    max_size_bytes:
+#    message_counter_history_day_limit:
+#    address_full_policy:
+#    permissions:
+#      - grant: consume
+#        roles:
+#          - admin
+#          - user
+#      - grant: browse
+#        roles:
+#          - admin
+#          - user
+#      - grant: send
+#        roles:
+#          - admin
+#          - user
+#      - grant: manage
+#        roles:
+#          - admin


### PR DESCRIPTION
Don't create default queues or users. They are hard to override and could slip into production environments.