### PR TITLE
Feature/optional nodeport

### DIFF
--- a/helm/persistence/templates/deployment.yaml
+++ b/helm/persistence/templates/deployment.yaml
@@ -1,18 +1,16 @@
 ---
-apiVersion: apps.openshift.io/v1
-kind: DeploymentConfig
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   labels:
     application: {{ .Values.application.name }}
   name: {{ tpl .Values.templates.deployment . }}
 spec:
   replicas: 1
+  revisionHistoryLimit: 2
   selector:
-    deploymentConfig: {{ tpl .Values.templates.deployment . }}
-  strategy:
-    rollingParams:
-      maxSurge: 0
-    type: Rolling
+    matchLabels:
+      application: {{ .Values.application.name }}
   template:
     metadata:
       # trigger deployments on config map changes
@@ -20,7 +18,7 @@ spec:
         configmap/checksum: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:
         application: {{ .Values.application.name }}
-        deploymentConfig: {{ tpl .Values.templates.deployment . }}
+        deployment: {{ tpl .Values.templates.deployment . }}
       name: {{ tpl .Values.templates.deployment . }}
     spec:
       containers:
@@ -102,5 +100,3 @@ spec:
         - name: {{ tpl .Values.templates.pvc_name . }}
           persistentVolumeClaim:
             claimName: {{ tpl .Values.templates.pvc_name . }}
-  triggers:
-  - type: {{ .Values.application.rolloutTrigger }}

--- a/helm/persistence/templates/nodeport.yaml
+++ b/helm/persistence/templates/nodeport.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.nodeport.enabled }}
 {{- $np_svc := .Values.nodeport }}
 {{- range .Values.service }}
 {{- if eq .name $np_svc.service }}
@@ -20,5 +21,6 @@ spec:
     application: {{ $.Values.application.name }}
   sessionAffinity: None
   type: NodePort
+{{- end }}
 {{- end }}
 {{- end }}

--- a/helm/persistence/templates/services.yaml
+++ b/helm/persistence/templates/services.yaml
@@ -17,5 +17,5 @@ spec:
   - port: {{ .port }}
     targetPort: {{ .port }}
   selector:
-    deploymentConfig: {{ $dc_name }}
+    deployment: {{ $dc_name }}
 {{- end }}

--- a/helm/persistence/values.yaml
+++ b/helm/persistence/values.yaml
@@ -74,7 +74,7 @@ users: []
 #      - user
 
 # Create queues
-queues: {}
+queues: []
 #  - name: QUEUE_1
 #    dlq_address: QUEUE_1_DLQ
 #    expiry_address:

--- a/helm/persistence/values.yaml
+++ b/helm/persistence/values.yaml
@@ -31,6 +31,7 @@ service:
 nodeport:
   port: 30002
   service: multiplex
+  enabled: true
 
 parameters:
   amq_protocols: "openwire,amq,stomp,mqtt,hornetq,core"

--- a/helm/persistence/values.yaml
+++ b/helm/persistence/values.yaml
@@ -62,38 +62,40 @@ admin:
   roles:
     - admin
 
-users:
-  - name: demouser
-    password: "demo"
-    roles:
-      - user
-  - name: anotheruser
-    password: "demo1"
-    roles:
-      - user
+# Create additional users
+users: []
+#  - name: demouser
+#    password: "demo"
+#    roles:
+#      - user
+#  - name: anotheruser
+#    password: "demo1"
+#    roles:
+#      - user
 
-queues:
-  - name: QUEUE_1
-    dlq_address: QUEUE_1_DLQ
-    expiry_address:
-    max_delivery_attempts:
-    redelivery_delay:
-    max_size_bytes:
-    message_counter_history_day_limit:
-    address_full_policy:
-    permissions:
-      - grant: consume
-        roles:
-          - admin
-          - user
-      - grant: browse
-        roles:
-          - admin
-          - user
-      - grant: send
-        roles:
-          - admin
-          - user
-      - grant: manage
-        roles:
-          - admin
+# Create queues
+queues: {}
+#  - name: QUEUE_1
+#    dlq_address: QUEUE_1_DLQ
+#    expiry_address:
+#    max_delivery_attempts:
+#    redelivery_delay:
+#    max_size_bytes:
+#    message_counter_history_day_limit:
+#    address_full_policy:
+#    permissions:
+#      - grant: consume
+#        roles:
+#          - admin
+#          - user
+#      - grant: browse
+#        roles:
+#          - admin
+#          - user
+#      - grant: send
+#        roles:
+#          - admin
+#          - user
+#      - grant: manage
+#        roles:
+#          - admin


### PR DESCRIPTION
NodePort is not needed if AMQ is only accessed within the Kubernetes cluster.