### PR TITLE
Optional creating NodePort

### DIFF
--- a/helm/persistence/templates/nodeport.yaml
+++ b/helm/persistence/templates/nodeport.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.nodeport.enabled }}
 {{- $np_svc := .Values.nodeport }}
 {{- range .Values.service }}
 {{- if eq .name $np_svc.service }}
@@ -20,5 +21,6 @@ spec:
     application: {{ $.Values.application.name }}
   sessionAffinity: None
   type: NodePort
+{{- end }}
 {{- end }}
 {{- end }}

--- a/helm/persistence/values.yaml
+++ b/helm/persistence/values.yaml
@@ -31,6 +31,7 @@ service:
 nodeport:
   port: 30002
   service: multiplex
+  enabled: true
 
 parameters:
   amq_protocols: "openwire,amq,stomp,mqtt,hornetq,core"


### PR DESCRIPTION
NodePort is not needed when AMQ is only used within a Kubernetes cluster.