### PR TITLE
Added support for users/passwords from existing secret

### DIFF
--- a/helm/persistence/conf/artemis-users.properties
+++ b/helm/persistence/conf/artemis-users.properties
@@ -16,8 +16,10 @@
 ## ---------------------------------------------------------------------------
 ## CUSTOMCONFIG
 
+{{- if .Values.admin.password }}
 # ADMIN USER
 {{ .Values.admin.user }} = {{ .Values.admin.password }}
+{{- end }}
 
 # ADDITIONAL USERS
 {{- range .Values.users }}

--- a/helm/persistence/conf/artemis-users.properties
+++ b/helm/persistence/conf/artemis-users.properties
@@ -1,3 +1,4 @@
+{{- if .Values.security.createSecret }}
 ## ---------------------------------------------------------------------------
 ## Licensed to the Apache Software Foundation (ASF) under one or more
 ## contributor license agreements.  See the NOTICE file distributed with
@@ -16,12 +17,12 @@
 ## ---------------------------------------------------------------------------
 ## CUSTOMCONFIG
 
-{{- if .Values.admin.password }}
 # ADMIN USER
 {{ .Values.admin.user }} = {{ .Values.admin.password }}
-{{- end }}
 
 # ADDITIONAL USERS
 {{- range .Values.users }}
 {{ .name }} = {{ .password }}
+{{- end }}
+
 {{- end }}

--- a/helm/persistence/conf/broker.xml
+++ b/helm/persistence/conf/broker.xml
@@ -163,4 +163,3 @@
       </addresses>
    </core>
 </configuration>
-  

--- a/helm/persistence/conf/broker.xml
+++ b/helm/persistence/conf/broker.xml
@@ -53,6 +53,7 @@
          <!-- MQTT Acceptor -->
          <acceptor name="mqtt">tcp://${BROKER_IP}:1883?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=MQTT;useEpoll=true</acceptor>
       </acceptors>
+      <security-enabled>{{ .Values.security.enabled }}</security-enabled>
       <security-settings>
       {{- range .Values.queues }}
         <security-setting match="{{ .name }}">

--- a/helm/persistence/conf/login.config
+++ b/helm/persistence/conf/login.config
@@ -18,6 +18,6 @@
 activemq {
    org.apache.activemq.artemis.spi.core.security.jaas.PropertiesLoginModule requisite
        reload=true
-       org.apache.activemq.jaas.properties.user="artemis-users.properties"
+       org.apache.activemq.jaas.properties.user="{{ .Values.security.jaasUsers.key }}"
        org.apache.activemq.jaas.properties.role="artemis-roles.properties";
 };

--- a/helm/persistence/templates/deployment.yaml
+++ b/helm/persistence/templates/deployment.yaml
@@ -95,8 +95,14 @@ spec:
                 path: configure_custom_config.sh
             defaultMode: 0550
         - name: broker-config-volume
-          configMap:
-            name: {{ tpl .Values.templates.config_cm . }}
+          projected:
+            sources:
+            - configMap:
+                name: {{ tpl .Values.templates.config_cm . }}
+            {{- range .Values.security.secrets }}
+            - secret:
+                name: {{ . }}
+            {{- end }}
         - name: {{ tpl .Values.templates.pvc_name . }}
           persistentVolumeClaim:
             claimName: {{ tpl .Values.templates.pvc_name . }}

--- a/helm/persistence/templates/route.yaml
+++ b/helm/persistence/templates/route.yaml
@@ -9,3 +9,7 @@ spec:
   to:
     kind: Service
     name: {{ tpl .Values.templates.service .}}-jolokia
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+  wildcardPolicy: None

--- a/helm/persistence/templates/secrets.yaml
+++ b/helm/persistence/templates/secrets.yaml
@@ -1,4 +1,4 @@
----
+{{- if .Values.security.createSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,3 +7,4 @@ type: Opaque
 data:
   AMQ_USER: {{ b64enc .Values.admin.user }}
   AMQ_PASSWORD: {{ b64enc .Values.admin.password }}
+{{- end }}

--- a/helm/persistence/values.yaml
+++ b/helm/persistence/values.yaml
@@ -57,6 +57,15 @@ templates:
   app_secret: "{{ .Values.application.name }}-secret"
   pvc_name: "{{ .Values.application.name}}-persistent-volume"
 
+security:
+  enabled: true
+  # Names of additional secrets to mount into configuration folder.
+  secrets: []
+  createSecret: true
+  jaasUsers:
+    # Secret key entry name for Username password properties file. Override when files is provided by existing Secret.
+    key: artemis-users.properties
+
 admin:
   user: admin
   password: password


### PR DESCRIPTION
We need to be able to have passwords in Secrets instead of clear text. Specially when using GitOps for deployment.
This pull-request adds support for using existing Secret containing users and their passwords.

Also added SSL to Console route - should probably have moved that to another pull-request.

