### PR TITLE
Feature/updates for 7.10

### DIFF
--- a/artemis-broker/conf/bootstrap.xml
+++ b/artemis-broker/conf/bootstrap.xml
@@ -17,7 +17,7 @@
   ~ limitations under the License.
   -->
 
-<broker xmlns="http://activemq.org/schema">
+<broker xmlns="http://activemq.apache.org/schema">
 
    <jaas-security domain="activemq"/>
 

--- a/artemis-broker/conf/jgroups-ping.xml
+++ b/artemis-broker/conf/jgroups-ping.xml
@@ -1,56 +1,34 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns="urn:org:jgroups"
         xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups.xsd">
-    <TCP bind_port="7800"
+    <TCP bind_addr="${jgroups.bind_addr:site_local}"
+         bind_port="${jgroups.bind_port:{{ .Values.ping_service.jgroups.bind_port }}}"
+         external_addr="${jgroups.external_addr}"
+         external_port="${jgroups.external_port}"
+         thread_pool.min_threads="0"
+         thread_pool.max_threads="200"
+         thread_pool.keep_alive_time="30000"/>
+    <RED/>
 
-         recv_buf_size="${tcp.recv_buf_size:5M}"
-         send_buf_size="${tcp.send_buf_size:5M}"
-         max_bundle_size="64K"
-         max_bundle_timeout="30"
-         use_send_queues="true"
-         sock_conn_timeout="300"
+    <dns.DNS_PING 
+        dns_query="{{ tpl .Values.ping_service.name . }}" 
+        dns_record_type="${DNS_RECORD_TYPE:A}"
+    />
 
-         timer_type="new3"
-         timer.min_threads="4"
-         timer.max_threads="10"
-         timer.keep_alive_time="3000"
-         timer.queue_max_size="500"
-
-         thread_pool.enabled="true"
-         thread_pool.min_threads="2"
-         thread_pool.max_threads="8"
-         thread_pool.keep_alive_time="5000"
-         thread_pool.queue_enabled="true"
-         thread_pool.queue_max_size="10000"
-         thread_pool.rejection_policy="discard"
-
-         oob_thread_pool.enabled="true"
-         oob_thread_pool.min_threads="1"
-         oob_thread_pool.max_threads="8"
-         oob_thread_pool.keep_alive_time="5000"
-         oob_thread_pool.queue_enabled="false"
-         oob_thread_pool.queue_max_size="100"
-         oob_thread_pool.rejection_policy="discard"/>
-
-    <openshift.DNS_PING timeout="3000" serviceName="{{ tpl .Values.ping_service.name . }}" />
-
-    <MERGE3  min_interval="10000"
-             max_interval="30000"/>
-    <FD_SOCK/>
-    <FD timeout="3000" max_tries="3" />
-    <VERIFY_SUSPECT timeout="1500"  />
-    <BARRIER />
-    <pbcast.NAKACK2 use_mcast_xmit="false"
-                   discard_delivered_msgs="true"/>
+    <MERGE3 min_interval="10000"
+            max_interval="30000" />
+    <FD_SOCK2/>
+    <FD_ALL3 timeout="40000" interval="5000" />
+    <VERIFY_SUSPECT2 timeout="1500" />
+    <pbcast.NAKACK2 use_mcast_xmit="false" />
     <UNICAST3 />
-    <pbcast.STABLE stability_delay="1000" desired_avg_gossip="50000"
+    <pbcast.STABLE desired_avg_gossip="50000"
                    max_bytes="4M"/>
-    <pbcast.GMS print_local_addr="true"
-                view_bundling="true"/>
-     <MFC max_credits="2M"
+    <pbcast.GMS print_local_addr="true" join_timeout="2000"/>
+    <UFC max_credits="2M"
+         min_threshold="0.4"/>
+    <MFC max_credits="2M"
          min_threshold="0.4"/>
     <FRAG2 frag_size="60K"  />
-    <!--RSVP resend_interval="2000" timeout="10000"/-->
-    <pbcast.STATE_TRANSFER/>
 </config>
 

--- a/artemis-broker/templates/_drain.tpl
+++ b/artemis-broker/templates/_drain.tpl
@@ -112,7 +112,7 @@ statefulsets.kubernetes.io/drainer-pod-template: |
             },
             {
               "name": "OPENSHIFT_DNS_PING_SERVICE_PORT",
-              "value": "{{ .Values.ping_service.port}}"
+              "value": "{{ .Values.ping_service.jgroups.bind_port }}"
             }
           ],
           "image": "{{ tpl .Values.templates.broker_image .}}",

--- a/artemis-broker/templates/_pod.tpl
+++ b/artemis-broker/templates/_pod.tpl
@@ -24,6 +24,8 @@ containers:
       secretKeyRef:
         name: {{ tpl .Values.templates.app_secret . }}
         key: AMQ_CLUSTER_PASSWORD
+  - name: OPENSHIFT_DNS_PING_SERVICE_PORT
+    value: "{{ .Values.ping_service.jgroups.bind_port }}"
   - name: POD_NAMESPACE
     valueFrom:
       fieldRef:

--- a/artemis-broker/values.yaml
+++ b/artemis-broker/values.yaml
@@ -8,7 +8,7 @@ platform: openshift
 
 application:
   name: amq-broker-artemis
-  amq_broker_version: 7.8
+  amq_broker_version: 7.10
   amq_broker_image: registry.redhat.io/amq7/amq-broker
   pullPolicy: IfNotPresent
   persistent: true
@@ -45,6 +45,8 @@ service:
 ping_service:
   name: "{{ .Values.application.name }}-ping-svc"
   port: 8888
+  jgroups:
+    bind_port: 7800
 
 nodeport:
   port: 30003


### PR DESCRIPTION
Upgrading amq_broker_version to 7.10 is failing due to the following reasons:

* changes in the xmlns schema for bootstrap.xml and management.xml
[Upgrading a broker instance from 7.9.x to 7.10.x](https://access.redhat.com/documentation/it-it/red_hat_amq_broker/7.10/html/managing_amq_broker/patching#upgrading_7.10_linux)

* openshift.DNS in jgroups-ping.xml is not supported anymore
https://issues.redhat.com/browse/JBEAP-16038

This changes are breaking compatibility with older version. Evaluate using conditionals based on `application.amq_broker_version`

Resolves #28 